### PR TITLE
Ignore additional parameters and case for Content-Type response header

### DIFF
--- a/src/EventSource.php
+++ b/src/EventSource.php
@@ -82,7 +82,8 @@ class EventSource extends EventEmitter
                 return;
             }
 
-            if ($response->getHeaderLine('Content-Type') !== 'text/event-stream') {
+            // match `Content-Type: text/event-stream` (case insensitve and ignore additional parameters)
+            if (!preg_match('/^text\/event-stream(?:$|;)/i', $response->getHeaderLine('Content-Type'))) {
                 $this->readyState = self::CLOSED;
                 $this->emit('error', array(new \UnexpectedValueException('Unexpected Content-Type')));
                 $this->close();


### PR DESCRIPTION
For example, `CONTENT-type: TEXT/event-stream;charset=UTF-8` is a valid
response header. See
https://html.spec.whatwg.org/multipage/server-sent-events.html and
https://tools.ietf.org/html/rfc2045#section-2