### PR TITLE
Support for custom HTTP headers

### DIFF
--- a/src/EventSource.php
+++ b/src/EventSource.php
@@ -96,13 +96,31 @@ class EventSource extends EventEmitter
         $this->browser = $browser->withOptions(array('streaming' => true, 'obeySuccessCode' => false));
         $this->loop = $loop;
         $this->url = $url;
-        $this->headers = array_merge(
-            $headers,
-            $this->defaultHeaders
-        );
+
+        $this->headers = $this->mergeHeaders($headers);
 
         $this->readyState = self::CONNECTING;
         $this->request();
+    }
+
+    private function mergeHeaders(array $headers = [])
+    {
+        if ($headers === []) {
+            return $this->defaultHeaders;
+        }
+
+        // HTTP headers are case insensitive, we do not want to have different cases for the same (default) header
+        // Convert default headers to lowercase, to ease the custom headers potential override comparison
+        $loweredDefaults = array_change_key_case($this->defaultHeaders, CASE_LOWER);
+        foreach($headers as $k => $v) {
+            if (array_key_exists(strtolower($k), $loweredDefaults)) {
+                unset($headers[$k]);
+            }
+        }
+        return array_merge(
+            $headers,
+            $this->defaultHeaders
+        );
     }
 
     private function request()

--- a/src/EventSource.php
+++ b/src/EventSource.php
@@ -77,8 +77,13 @@ class EventSource extends EventEmitter
     private $request;
     private $timer;
     private $reconnectTime = 3.0;
+    private $headers;
+    private $defaultHeaders = [
+        'Accept' => 'text/event-stream',
+        'Cache-Control' => 'no-cache'
+    ];
 
-    public function __construct($url, LoopInterface $loop, Browser $browser = null)
+    public function __construct($url, LoopInterface $loop, Browser $browser = null, array $headers = [])
     {
         $parts = parse_url($url);
         if (!isset($parts['scheme'], $parts['host']) || !in_array($parts['scheme'], array('http', 'https'))) {
@@ -91,6 +96,10 @@ class EventSource extends EventEmitter
         $this->browser = $browser->withOptions(array('streaming' => true, 'obeySuccessCode' => false));
         $this->loop = $loop;
         $this->url = $url;
+        $this->headers = array_merge(
+            $headers,
+            $this->defaultHeaders
+        );
 
         $this->readyState = self::CONNECTING;
         $this->request();
@@ -98,10 +107,7 @@ class EventSource extends EventEmitter
 
     private function request()
     {
-        $headers = array(
-            'Accept' => 'text/event-stream',
-            'Cache-Control' => 'no-cache'
-        );
+        $headers = $this->headers;
         if ($this->lastEventId !== '') {
             $headers['Last-Event-ID'] = $this->lastEventId;
         }

--- a/tests/EventSourceTest.php
+++ b/tests/EventSourceTest.php
@@ -83,7 +83,7 @@ class EventSourceTest extends TestCase
         // but this ensures the defaults are not altered by hardcoding their values in this test 
         $this->assertEquals(array(
             'Accept' => 'text/event-stream',
-            'Cache-Control' => 'only-if-cached',
+            'Cache-Control' => 'no-cache',
             'x-custom' => '1234'
         ), $headers);
     }

--- a/tests/EventSourceTest.php
+++ b/tests/EventSourceTest.php
@@ -73,7 +73,12 @@ class EventSourceTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $es = new EventSource('http://example.valid', $loop, null, ['x-custom' => '1234', 'Cache-Control' => 'only-if-cached']);
+        $es = new EventSource('http://example.valid', $loop, null, array(
+            'x-custom' => '1234',
+            'Cache-Control' => 'only-if-cached',
+            'ACCEPT' => 'no-store',
+            'cache-control' => 'none'
+        ));
 
         $ref = new ReflectionProperty($es, 'headers');
         $ref->setAccessible(true);

--- a/tests/EventSourceTest.php
+++ b/tests/EventSourceTest.php
@@ -51,6 +51,43 @@ class EventSourceTest extends TestCase
         $this->assertInstanceOf('Clue\React\Buzz\Browser', $browser);
     }
 
+        
+    public function testConstructorCanBeCalledWithoutCustomHeaders()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $es = new EventSource('http://example.valid', $loop);
+
+        $ref = new ReflectionProperty($es, 'headers');
+        $ref->setAccessible(true);
+        $headers = $ref->getValue($es);
+
+        $ref = new ReflectionProperty($es, 'defaultHeaders');
+        $ref->setAccessible(true);
+        $defaultHeaders = $ref->getValue($es);
+        
+        $this->assertEquals($defaultHeaders, $headers);
+    }
+
+    public function testConstructorCanBeCalledWithCustomHeaders()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $es = new EventSource('http://example.valid', $loop, null, ['x-custom' => '1234']);
+
+        $ref = new ReflectionProperty($es, 'headers');
+        $ref->setAccessible(true);
+        $headers = $ref->getValue($es);
+
+        // Could have used the defaultHeaders property on EventSource, 
+        // but this ensures the defaults are not altered by hardcoding their values in this test 
+        $this->assertEquals(array(
+            'Accept' => 'text/event-stream',
+            'Cache-Control' => 'no-cache',
+            'x-custom' => '1234'
+        ), $headers);
+    }
+
     public function testConstructorWillSendGetRequestThroughGivenBrowser()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();

--- a/tests/EventSourceTest.php
+++ b/tests/EventSourceTest.php
@@ -73,7 +73,7 @@ class EventSourceTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $es = new EventSource('http://example.valid', $loop, null, ['x-custom' => '1234']);
+        $es = new EventSource('http://example.valid', $loop, null, ['x-custom' => '1234', 'Cache-Control' => 'only-if-cached']);
 
         $ref = new ReflectionProperty($es, 'headers');
         $ref->setAccessible(true);
@@ -83,7 +83,7 @@ class EventSourceTest extends TestCase
         // but this ensures the defaults are not altered by hardcoding their values in this test 
         $this->assertEquals(array(
             'Accept' => 'text/event-stream',
-            'Cache-Control' => 'no-cache',
+            'Cache-Control' => 'only-if-cached',
             'x-custom' => '1234'
         ), $headers);
     }


### PR DESCRIPTION
Hello, and thanks for your work on EventSourcing from backend with Promises ! 

I'd like to use this lib. to set up a backend subscriber, but there was a lack of support with custom headers, preventing me to subscribe to my SSE server (I have to provide Authorization Bearers header into HTTP requests).

This PR enables custom headers to be sent into HTTP headers of the EventSource's request.

Tests have been updated accordingly & I'm currently using it in my dev. stack.

Cheers,
Quentin H.