### PR TITLE
[Rebased] Support for custom HTTP headers

### DIFF
--- a/src/EventSource.php
+++ b/src/EventSource.php
@@ -96,13 +96,31 @@ class EventSource extends EventEmitter
         $this->browser = $browser->withRejectErrorResponse(false);
         $this->loop = $loop;
         $this->url = $url;
-        $this->headers = array_merge(
-            $headers,
-            $this->defaultHeaders
-        );
+
+        $this->headers = $this->mergeHeaders($headers);
 
         $this->readyState = self::CONNECTING;
         $this->request();
+    }
+
+    private function mergeHeaders(array $headers = [])
+    {
+        if ($headers === []) {
+            return $this->defaultHeaders;
+        }
+
+        // HTTP headers are case insensitive, we do not want to have different cases for the same (default) header
+        // Convert default headers to lowercase, to ease the custom headers potential override comparison
+        $loweredDefaults = array_change_key_case($this->defaultHeaders, CASE_LOWER);
+        foreach($headers as $k => $v) {
+            if (array_key_exists(strtolower($k), $loweredDefaults)) {
+                unset($headers[$k]);
+            }
+        }
+        return array_merge(
+            $headers,
+            $this->defaultHeaders
+        );
     }
 
     private function request()

--- a/src/EventSource.php
+++ b/src/EventSource.php
@@ -77,8 +77,13 @@ class EventSource extends EventEmitter
     private $request;
     private $timer;
     private $reconnectTime = 3.0;
+    private $headers;
+    private $defaultHeaders = [
+        'Accept' => 'text/event-stream',
+        'Cache-Control' => 'no-cache'
+    ];
 
-    public function __construct($url, LoopInterface $loop, Browser $browser = null)
+    public function __construct($url, LoopInterface $loop, Browser $browser = null, array $headers = [])
     {
         $parts = parse_url($url);
         if (!isset($parts['scheme'], $parts['host']) || !in_array($parts['scheme'], array('http', 'https'))) {
@@ -91,6 +96,10 @@ class EventSource extends EventEmitter
         $this->browser = $browser->withRejectErrorResponse(false);
         $this->loop = $loop;
         $this->url = $url;
+        $this->headers = array_merge(
+            $headers,
+            $this->defaultHeaders
+        );
 
         $this->readyState = self::CONNECTING;
         $this->request();
@@ -98,10 +107,7 @@ class EventSource extends EventEmitter
 
     private function request()
     {
-        $headers = array(
-            'Accept' => 'text/event-stream',
-            'Cache-Control' => 'no-cache'
-        );
+        $headers = $this->headers;
         if ($this->lastEventId !== '') {
             $headers['Last-Event-ID'] = $this->lastEventId;
         }

--- a/tests/EventSourceTest.php
+++ b/tests/EventSourceTest.php
@@ -69,7 +69,7 @@ class EventSourceTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $es = new EventSource('http://example.valid', $loop, null, ['x-custom' => '1234']);
+        $es = new EventSource('http://example.valid', $loop, null, ['x-custom' => '1234', 'Cache-Control' => 'only-if-cached']);
 
         $ref = new ReflectionProperty($es, 'headers');
         $ref->setAccessible(true);
@@ -79,7 +79,7 @@ class EventSourceTest extends TestCase
         // but this ensures the defaults are not altered by hardcoding their values in this test 
         $this->assertEquals(array(
             'Accept' => 'text/event-stream',
-            'Cache-Control' => 'no-cache',
+            'Cache-Control' => 'only-if-cached',
             'x-custom' => '1234'
         ), $headers);
     }

--- a/tests/EventSourceTest.php
+++ b/tests/EventSourceTest.php
@@ -69,7 +69,12 @@ class EventSourceTest extends TestCase
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
 
-        $es = new EventSource('http://example.valid', $loop, null, ['x-custom' => '1234', 'Cache-Control' => 'only-if-cached']);
+        $es = new EventSource('http://example.valid', $loop, null, array(
+            'x-custom' => '1234',
+            'Cache-Control' => 'only-if-cached',
+            'ACCEPT' => 'no-store',
+            'cache-control' => 'none'
+        ));
 
         $ref = new ReflectionProperty($es, 'headers');
         $ref->setAccessible(true);

--- a/tests/EventSourceTest.php
+++ b/tests/EventSourceTest.php
@@ -79,7 +79,7 @@ class EventSourceTest extends TestCase
         // but this ensures the defaults are not altered by hardcoding their values in this test 
         $this->assertEquals(array(
             'Accept' => 'text/event-stream',
-            'Cache-Control' => 'only-if-cached',
+            'Cache-Control' => 'no-cache',
             'x-custom' => '1234'
         ), $headers);
     }

--- a/tests/EventSourceTest.php
+++ b/tests/EventSourceTest.php
@@ -47,6 +47,43 @@ class EventSourceTest extends TestCase
         $this->assertInstanceOf('React\Http\Browser', $browser);
     }
 
+        
+    public function testConstructorCanBeCalledWithoutCustomHeaders()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $es = new EventSource('http://example.valid', $loop);
+
+        $ref = new ReflectionProperty($es, 'headers');
+        $ref->setAccessible(true);
+        $headers = $ref->getValue($es);
+
+        $ref = new ReflectionProperty($es, 'defaultHeaders');
+        $ref->setAccessible(true);
+        $defaultHeaders = $ref->getValue($es);
+        
+        $this->assertEquals($defaultHeaders, $headers);
+    }
+
+    public function testConstructorCanBeCalledWithCustomHeaders()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $es = new EventSource('http://example.valid', $loop, null, ['x-custom' => '1234']);
+
+        $ref = new ReflectionProperty($es, 'headers');
+        $ref->setAccessible(true);
+        $headers = $ref->getValue($es);
+
+        // Could have used the defaultHeaders property on EventSource, 
+        // but this ensures the defaults are not altered by hardcoding their values in this test 
+        $this->assertEquals(array(
+            'Accept' => 'text/event-stream',
+            'Cache-Control' => 'no-cache',
+            'x-custom' => '1234'
+        ), $headers);
+    }
+
     public function testConstructorWillSendGetRequestThroughGivenBrowser()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();

--- a/tests/EventSourceTest.php
+++ b/tests/EventSourceTest.php
@@ -6,9 +6,9 @@ use Clue\React\EventSource\EventSource;
 use PHPUnit\Framework\TestCase;
 use React\Promise\Promise;
 use React\Promise\Deferred;
-use React\Http\Browser;
 use React\Http\Io\ReadableBodyStream;
 use React\Stream\ThroughStream;
+use ReflectionProperty;
 use RingCentral\Psr7\Response;
 
 class EventSourceTest extends TestCase
@@ -47,7 +47,7 @@ class EventSourceTest extends TestCase
         $this->assertInstanceOf('React\Http\Browser', $browser);
     }
 
-        
+
     public function testConstructorCanBeCalledWithoutCustomHeaders()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -61,7 +61,7 @@ class EventSourceTest extends TestCase
         $ref = new ReflectionProperty($es, 'defaultHeaders');
         $ref->setAccessible(true);
         $defaultHeaders = $ref->getValue($es);
-        
+
         $this->assertEquals($defaultHeaders, $headers);
     }
 
@@ -80,8 +80,8 @@ class EventSourceTest extends TestCase
         $ref->setAccessible(true);
         $headers = $ref->getValue($es);
 
-        // Could have used the defaultHeaders property on EventSource, 
-        // but this ensures the defaults are not altered by hardcoding their values in this test 
+        // Could have used the defaultHeaders property on EventSource,
+        // but this ensures the defaults are not altered by hardcoding their values in this test
         $this->assertEquals(array(
             'Accept' => 'text/event-stream',
             'Cache-Control' => 'no-cache',


### PR DESCRIPTION
Hello @clue, 

This one is a rebased version of #10. When you've got some little time, could you please review this?
If you merge, please co-author @qharnay since he did the biggest part of the job :-) 

Do you plan to tag a 0.1? I'll soon require that dependency on a production app (server listening to a Mercure server, with authentication) and even if not considered stable, at least avoid relying `dev-master` in case of breaking changes.

Thank you much!
Ben