### PR TITLE
Simplify usage by supporting new HTTP API and new Socket API

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ to the [`Browser`](https://github.com/reactphp/http#browser) instance
 and pass it as an additional argument to the `EventSource` like this:
 
 ```php
-$connector = new React\Socket\Connector(null, [
+$connector = new React\Socket\Connector([
     'dns' => '127.0.0.1',
     'tcp' => [
         'bindto' => '192.168.10.1:0'
@@ -72,7 +72,7 @@ $connector = new React\Socket\Connector(null, [
         'verify_peer_name' => false
     ]
 ]);
-$browser = new React\Http\Browser(null, $connector);
+$browser = new React\Http\Browser($connector);
 
 $es = new Clue\React\EventSource\EventSource('https://example.com/stream.php', null, $browser);
 ```

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.4",
         "evenement/evenement": "^3.0 || ^2.0",
         "react/event-loop": "^1.2",
-        "react/http": "^1.4"
+        "react/http": "^1.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"

--- a/src/EventSource.php
+++ b/src/EventSource.php
@@ -96,7 +96,7 @@ class EventSource extends EventEmitter
 
         $this->loop = $loop ?: Loop::get();
         if ($browser === null) {
-            $browser = new Browser($this->loop);
+            $browser = new Browser(null, $this->loop);
         }
         $this->browser = $browser->withRejectErrorResponse(false);
         $this->url = $url;


### PR DESCRIPTION
This changeset simplifies usage by supporting the new HTTP API and the new Socket API without nullable loop arguments.

Note that this doesn't affect the API of this package at all, but does use the improved APIs of the referenced HTTP component. Existing code continues to work as is.

Together with #22, this means we can now fully rely on the [default loop](https://github.com/reactphp/event-loop#loop) and no longer need to skip any arguments with null values.

Builds on top of reactphp/http#418 and reactphp/socket#264