### PR TITLE
Make `Browser` second constructor argument, de-emphasize default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,6 @@ Its constructor simply requires the URL to the remote Server-Sent Events (SSE) e
 $es = new Clue\React\EventSource\EventSource('https://example.com/stream.php');
 ```
 
-This class takes an optional `LoopInterface|null $loop` parameter that can be used to
-pass the event loop instance to use for this object. You can use a `null` value
-here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
-This value SHOULD NOT be given unless you're sure you want to explicitly use a
-given event loop instance.
-
 If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
 proxy servers etc.), you can explicitly pass a custom instance of the
 [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface)
@@ -74,8 +68,14 @@ $connector = new React\Socket\Connector([
 ]);
 $browser = new React\Http\Browser($connector);
 
-$es = new Clue\React\EventSource\EventSource('https://example.com/stream.php', null, $browser);
+$es = new Clue\React\EventSource\EventSource('https://example.com/stream.php', $browser);
 ```
+
+This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+pass the event loop instance to use for this object. You can use a `null` value
+here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+This value SHOULD NOT be given unless you're sure you want to explicitly use a
+given event loop instance.
 
 ## Install
 

--- a/src/EventSource.php
+++ b/src/EventSource.php
@@ -82,12 +82,52 @@ class EventSource extends EventEmitter
     private $reconnectTime = 3.0;
 
     /**
+     * The `EventSource` class is responsible for communication with the remote Server-Sent Events (SSE) endpoint.
+     *
+     * The `EventSource` object works very similar to the one found in common
+     * web browsers. Unless otherwise noted, it follows the same semantics as defined
+     * under https://html.spec.whatwg.org/multipage/server-sent-events.html
+     *
+     * Its constructor simply requires the URL to the remote Server-Sent Events (SSE) endpoint:
+     *
+     * ```php
+     * $es = new Clue\React\EventSource\EventSource('https://example.com/stream.php');
+     * ```
+     *
+     * If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
+     * proxy servers etc.), you can explicitly pass a custom instance of the
+     * [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface)
+     * to the [`Browser`](https://github.com/reactphp/http#browser) instance
+     * and pass it as an additional argument to the `EventSource` like this:
+     *
+     * ```php
+     * $connector = new React\Socket\Connector([
+     *     'dns' => '127.0.0.1',
+     *     'tcp' => [
+     *         'bindto' => '192.168.10.1:0'
+     *     ],
+     *     'tls' => [
+     *         'verify_peer' => false,
+     *         'verify_peer_name' => false
+     *     ]
+     * ]);
+     * $browser = new React\Http\Browser($connector);
+     *
+     * $es = new Clue\React\EventSource\EventSource('https://example.com/stream.php', $browser);
+     * ```
+     *
+     * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+     * pass the event loop instance to use for this object. You can use a `null` value
+     * here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+     * This value SHOULD NOT be given unless you're sure you want to explicitly use a
+     * given event loop instance.
+     *
      * @param string         $url
-     * @param ?LoopInterface $loop
      * @param ?Browser       $browser
+     * @param ?LoopInterface $loop
      * @throws \InvalidArgumentException for invalid URL
      */
-    public function __construct($url, LoopInterface $loop = null, Browser $browser = null)
+    public function __construct($url, Browser $browser = null, LoopInterface $loop = null)
     {
         $parts = parse_url($url);
         if (!isset($parts['scheme'], $parts['host']) || !in_array($parts['scheme'], array('http', 'https'))) {


### PR DESCRIPTION
This changeset simplifies usage by making the `Browser` the second argument and the `LoopInterface` the last argument to de-emphasize the default loop. Most consumers of this package are not expected to use either parameter, so this should not affect them. This is a BC break for more advanced use cases that do require either argument.

Together with #22 and #23, this means we can now fully rely on the [default loop](https://github.com/reactphp/event-loop#loop) and no longer need to skip any arguments with null values.

```php
// old
$es = new Clue\React\EventSource\EventSource('https://example.com/stream.php');
$es = new Clue\React\EventSource\EventSource('https://example.com/stream.php', null, $browser);
$es = new Clue\React\EventSource\EventSource('https://example.com/stream.php', $loop, $browser);

// new
$es = new Clue\React\EventSource\EventSource('https://example.com/stream.php');
$es = new Clue\React\EventSource\EventSource('https://example.com/stream.php', $browser);
$es = new Clue\React\EventSource\EventSource('https://example.com/stream.php', $browser, $loop);
```

Refs #10/#17 to simplify passing a custom `Browser` object which could potentially hold custom default headers.

Builds on top of #22, #23, #4 and possibly others