### PR TITLE
Update CI setup to ensure 100% code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,13 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
       - run: composer install
-      - run: vendor/bin/phpunit --coverage-text
+      - run: vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml
         if: ${{ matrix.php >= 7.3 }}
-      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
+      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy --coverage-clover=clover.xml
         if: ${{ matrix.php < 7.3 }}
+      - name: Check 100% code coverage
+        shell: php {0}
+        run: |
+          <?php
+          $metrics = simplexml_load_file('clover.xml')->project->metrics;
+          exit((int) $metrics['statements'] === (int) $metrics['coveredstatements'] ? 0 : 1);


### PR DESCRIPTION
This minimal PR updates the CI setup to ensure that PHPUnit always reports 100% code coverage. It does so by instructing PHPUnit to write an additional `clover.xml` file which we then inspect to ensure all lines are covered.

Accordingly, all future changes need to have matching tests. Any future changes/PRs that add code without adding matching tests will fail. This will hopefully help us steer new contributors towards better code quality. Additionally, this is also a nice starting point to add future mutation tests in a follow-up PR.

See also discussion on Twitter: https://twitter.com/another_clue/status/1526551148643098624

Builds on top of #27