### PR TITLE
Refactor `retry` field handling, avoid internal `MessageEvent` property

### DIFF
--- a/src/EventSource.php
+++ b/src/EventSource.php
@@ -211,12 +211,8 @@ class EventSource extends EventEmitter
                 $buffer = array_pop($messageEvents);
 
                 foreach ($messageEvents as $data) {
-                    $message = MessageEvent::parse($data, $this->lastEventId);
+                    $message = MessageEvent::parse($data, $this->lastEventId, $this->reconnectTime);
                     $this->lastEventId = $message->lastEventId;
-
-                    if ($message->retry !== null) {
-                        $this->reconnectTime = $message->retry / 1000;
-                    }
 
                     if ($message->data !== '') {
                         $this->emit($message->type, array($message));

--- a/tests/MessageEventTest.php
+++ b/tests/MessageEventTest.php
@@ -123,14 +123,14 @@ class MessageEventTest extends TestCase
     public function retryTimeDataProvider()
     {
         return [
-            ['retry: 1234', 1234,],
-            ['retry: 0', 0,],
-            ['retry: ' . PHP_INT_MAX, PHP_INT_MAX,],
-            ['retry: ' . PHP_INT_MAX . '9', null,],
-            ['retry: 1.234', null,],
-            ['retry: now', null,],
-            ['retry: -1', null,],
-            ['retry: -1.234', null,],
+            ['retry: 1234', 1.234],
+            ['retry: 0', 0.0],
+            ['retry: ' . PHP_INT_MAX, PHP_INT_MAX * 0.001],
+            ['retry: ' . PHP_INT_MAX . '9', null],
+            ['retry: 1.234', null],
+            ['retry: now', null],
+            ['retry: -1', null],
+            ['retry: -1.234', null]
         ];
     }
 
@@ -139,8 +139,9 @@ class MessageEventTest extends TestCase
      */
     public function testParseRetryTime($input, $expected)
     {
-        $message = MessageEvent::parse($input, '');
+        $retryTime = null;
+        MessageEvent::parse($input, '', $retryTime);
 
-        $this->assertSame($expected, $message->retry);
+        $this->assertSame($expected, $retryTime);
     }
 }


### PR DESCRIPTION
Builds on top of #26 and #31