### PR TITLE
Public `MessageEvent` constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ of [ReactPHP](https://reactphp.org/)'s event-driven architecture.
         * [EventSource::$url](#eventsourceurl)
         * [close()](#close)
     * [MessageEvent](#messageevent)
+        * [MessageEvent::__construct()](#messageevent__construct)
         * [MessageEvent::$data](#messageeventdata)
         * [MessageEvent::$lastEventId](#messageeventlasteventid)
         * [MessageEvent::$type](#messageeventtype)
@@ -239,6 +240,19 @@ This will close any active connections or connection attempts and go into the
 ### MessageEvent
 
 The `MessageEvent` class represents an incoming EventSource message.
+
+#### MessageEvent::__construct()
+
+The `new MessageEvent(string $data, string $lastEventId = '', string $type = 'message')` constructor can be used to
+create a new `MessageEvent` instance.
+
+This is mostly used internally to represent each incoming message event
+(see also [`message` event](#message-event)). Likewise, you can also use
+this class in test cases to test how your application reacts to incoming
+messages.
+
+The constructor validates and initializes all properties of this class.
+It throws an `InvalidArgumentException` if any parameters are invalid.
 
 #### MessageEvent::$data
 

--- a/tests/MessageEventTest.php
+++ b/tests/MessageEventTest.php
@@ -175,4 +175,109 @@ class MessageEventTest extends TestCase
 
         $this->assertSame($expected, $retryTime);
     }
+
+    public function testConstructWithDefaultLastEventIdAndType()
+    {
+        $message = new MessageEvent('hello');
+
+        $this->assertEquals('hello', $message->data);
+        $this->assertEquals('', $message->lastEventId);
+        $this->assertEquals('message', $message->type);
+    }
+
+    public function testConstructWithEmptyDataAndId()
+    {
+        $message = new MessageEvent('', '');
+
+        $this->assertEquals('', $message->data);
+        $this->assertEquals('', $message->lastEventId);
+        $this->assertEquals('message', $message->type);
+    }
+
+    public function testConstructWithNullBytesInDataAndType()
+    {
+        $message = new MessageEvent("h\x00llo!", '', "h\x00llo!");
+
+        $this->assertEquals("h\x00llo!", $message->data);
+        $this->assertEquals('', $message->lastEventId);
+        $this->assertEquals("h\x00llo!", $message->type);
+    }
+
+    public function testConstructWithCarriageReturnAndLineFeedsInDataReplacedWithSimpleLineFeeds()
+    {
+        $message = new MessageEvent("hello\rworld!\r\n");
+
+        $this->assertEquals("hello\nworld!\n", $message->data);
+    }
+
+    public function testConstructWithInvalidDataUtf8Throws()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid $data given, must be valid UTF-8 string');
+        new MessageEvent("h\xFFllo!");
+    }
+
+    public function testConstructWithInvalidLastEventIdUtf8Throws()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid $lastEventId given, must be valid UTF-8 string with no null bytes or newline characters');
+        new MessageEvent('hello', "h\xFFllo");
+    }
+
+    public function testConstructWithInvalidLastEventIdNullThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid $lastEventId given, must be valid UTF-8 string with no null bytes or newline characters');
+        new MessageEvent('hello', "h\x00llo");
+    }
+
+    public function testConstructWithInvalidLastEventIdCarriageReturnThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid $lastEventId given, must be valid UTF-8 string with no null bytes or newline characters');
+        new MessageEvent('hello', "hello\r");
+    }
+
+    public function testConstructWithInvalidLastEventIdLineFeedThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid $lastEventId given, must be valid UTF-8 string with no null bytes or newline characters');
+        new MessageEvent('hello', "hello\n");
+    }
+
+    public function testConstructWithInvalidTypeUtf8Throws()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid $type given, must be valid UTF-8 string with no newline characters');
+        new MessageEvent('hello', '', "h\xFFllo");
+    }
+
+    public function testConstructWithInvalidTypeEmptyThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid $type given, must be valid UTF-8 string with no newline characters');
+        new MessageEvent('hello', '', '');
+    }
+
+    public function testConstructWithInvalidTypeCarriageReturnThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid $type given, must be valid UTF-8 string with no newline characters');
+        new MessageEvent('hello', '', "hello\r");
+    }
+
+    public function testConstructWithInvalidTypeLineFeedThrows()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid $type given, must be valid UTF-8 string with no newline characters');
+        new MessageEvent('hello', '', "hello\r");
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit < 5.2
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
 }


### PR DESCRIPTION
This changeset adds a public `MessageEvent` constructor. This class is mostly used internally to represent each incoming message event (see also `message` event). Likewise, you can also use this class in test cases to test how your application reacts to incoming messages.

Builds on top of #40, #36 and #31