### PR TITLE
Update test suite to support new reactphp/http `v1.10.0`

### DIFF
--- a/tests/EventSourceTest.php
+++ b/tests/EventSourceTest.php
@@ -5,10 +5,10 @@ namespace Clue\Tests\React\EventSource;
 use Clue\React\EventSource\EventSource;
 use PHPUnit\Framework\TestCase;
 use React\Http\Io\ReadableBodyStream;
+use React\Http\Message\Response;
 use React\Promise\Deferred;
 use React\Promise\Promise;
 use React\Stream\ThroughStream;
-use RingCentral\Psr7\Response;
 
 class EventSourceTest extends TestCase
 {


### PR DESCRIPTION
This changeset updates the test suite to support [reactphp/http `v1.10.0`](https://github.com/reactphp/http/releases/tag/v1.10.0). This new version of the ReactPHP HTTP component introduces its own PSR-7 implementation and removes the dependency for RingCentral (see https://github.com/reactphp/http/pull/522 for reference). This means we don't have to rely on the RingCentral dependency here as well, and instead can use ReactPHP's new PSR-7 implementation.

Builds on top of #28 and others