### PR TITLE
Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "php": ">=5.4",
         "evenement/evenement": "^3.0 || ^2.0",
         "react/event-loop": "^1.2",
-        "react/http": "^1.6",
-        "react/promise": "^3 || ^2.10 || ^1.2.1"
+        "react/http": "^1.11",
+        "react/promise": "^3.2 || ^2.10 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"

--- a/src/EventSource.php
+++ b/src/EventSource.php
@@ -150,11 +150,18 @@ class EventSource extends EventEmitter
      * @param ?LoopInterface $loop
      * @throws \InvalidArgumentException for invalid URL
      */
-    public function __construct($url, Browser $browser = null, LoopInterface $loop = null)
+    public function __construct($url, $browser = null, $loop = null)
     {
         $parts = parse_url($url);
         if (!isset($parts['scheme'], $parts['host']) || !in_array($parts['scheme'], array('http', 'https'))) {
             throw new \InvalidArgumentException();
+        }
+
+        if ($browser !== null && !$browser instanceof Browser) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #2 ($browser) expected null|React\Http\Browser');
+        }
+        if ($loop !== null && !$loop instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #3 ($loop) expected null|React\EventLoop\LoopInterface');
         }
 
         $this->loop = $loop ?: Loop::get();

--- a/tests/EventSourceTest.php
+++ b/tests/EventSourceTest.php
@@ -30,6 +30,18 @@ class EventSourceTest extends TestCase
         new EventSource('ftp://example.com');
     }
 
+    public function testCtorThrowsForInvalidBrowser()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Argument #2 ($browser) expected null|React\Http\Browser');
+        new EventSource('http://example.com', 'browser');
+    }
+
+    public function testCtorThrowsForInvalidLoop()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Argument #3 ($loop) expected null|React\EventLoop\LoopInterface');
+        new EventSource('http://example.com', null, 'loop');
+    }
+
     public function testConstructWithoutBrowserAndLoopAssignsBrowserAndLoopAutomatically()
     {
         $es = new EventSource('http://example.com');


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260. The same idea applies, but v1 requires manual type checks to support legacy PHP versions as the nullable type syntax requires PHP 7.1+ otherwise.

Builds on top of #45, #44, https://github.com/reactphp/promise/pull/260 and https://github.com/reactphp/http/pull/537.